### PR TITLE
91 api to start the game websocket handshake

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,10 @@ springBoot {
 
 dependencies {
     implementation 'org.mapstruct:mapstruct:1.3.1.Final'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.projectlombok:lombok:1.18.26'
+    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'org.testng:testng:7.1.0'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.3.1.Final'
     testAnnotationProcessor 'org.mapstruct:mapstruct-processor:1.3.1.Final'
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/constant/GameStatus.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/constant/GameStatus.java
@@ -1,0 +1,5 @@
+package ch.uzh.ifi.hase.soprafs24.constant;
+
+public enum GameStatus {
+    CREATED, ONGOING, TERMINATED
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/constant/MessageStatus.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/constant/MessageStatus.java
@@ -1,0 +1,5 @@
+package ch.uzh.ifi.hase.soprafs24.constant;
+
+public enum MessageStatus {
+    SUCCESS, ERROR
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/constant/MoveType.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/constant/MoveType.java
@@ -1,0 +1,5 @@
+package ch.uzh.ifi.hase.soprafs24.constant;
+
+public enum MoveType {
+    SUBMIT, VERIFY, EXCHANGE_TILES, SKIP
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Game.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Game.java
@@ -1,6 +1,9 @@
 package ch.uzh.ifi.hase.soprafs24.entity;
 
+import ch.uzh.ifi.hase.soprafs24.constant.GameStatus;
+
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,7 +19,35 @@ public class Game {
     @JoinTable(name = "game_user",
             joinColumns = @JoinColumn(name = "game_id"),
             inverseJoinColumns = @JoinColumn(name = "user_id"))
-    private List<User> players = new ArrayList<User>();
+    private List<User> users = new ArrayList<User>();
+
+    private String host;
+
+    @ElementCollection
+    private List<String> userOrder = new ArrayList<>();
+
+    private GameStatus gameStatus = GameStatus.CREATED;
+
+    @Column(name = "start_time")
+    private LocalDateTime startTime;
+
+
+
+    public List<User> getUsers() { return this.users; }
+    public void setUsers(List<User> users) { this.users = users; }
+    public void addUser(User user) { this.users.add(user); }
+
+    public String getHost() { return host; }
+    public void setHost(String host) { this.host = host; }
+
+    public List<String> getUserOrder() { return userOrder; }
+    public void setUserOrder(List<String> userOrder) { this.userOrder = userOrder; }
+
+    public GameStatus getGameStatus() { return gameStatus; }
+    public void setGameStatus(GameStatus gameStatus) { this.gameStatus = gameStatus; }
+
+    public LocalDateTime getStartTime() { return startTime; }
+    public void setStartTime(LocalDateTime startTime) { this.startTime = startTime; }
 
     public Long getId() {
         return id;
@@ -24,13 +55,5 @@ public class Game {
 
     public void setId(Long id) {
         this.id = id;
-    }
-
-    public List<User> getPlayers() {
-        return players;
-    }
-
-    public void setPlayers(List<User> players) {
-        this.players = players;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/exceptions/GlobalExceptionAdvice.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/exceptions/GlobalExceptionAdvice.java
@@ -2,13 +2,14 @@ package ch.uzh.ifi.hase.soprafs24.exceptions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.transaction.TransactionSystemException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.server.ResponseStatusException;
@@ -16,10 +17,15 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 import javax.servlet.http.HttpServletRequest;
 
-@ControllerAdvice(annotations = RestController.class)
+@ControllerAdvice
 public class GlobalExceptionAdvice extends ResponseEntityExceptionHandler {
 
-  private final Logger log = LoggerFactory.getLogger(GlobalExceptionAdvice.class);
+
+    @Autowired
+    private SimpMessagingTemplate simpleMessagingTemplate;
+
+
+    private final Logger log = LoggerFactory.getLogger(GlobalExceptionAdvice.class);
 
   @ExceptionHandler(value = { IllegalArgumentException.class, IllegalStateException.class })
   protected ResponseEntity<Object> handleConflict(RuntimeException ex, WebRequest request) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/GameRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/GameRepository.java
@@ -1,0 +1,11 @@
+package ch.uzh.ifi.hase.soprafs24.repository;
+
+import ch.uzh.ifi.hase.soprafs24.entity.Game;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository("gameRepository")
+public interface GameRepository extends JpaRepository<Game, Long> {
+    
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/GameStateDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/GameStateDTO.java
@@ -1,0 +1,68 @@
+package ch.uzh.ifi.hase.soprafs24.rest.dto;
+
+import ch.uzh.ifi.hase.soprafs24.constant.MoveType;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+public class GameStateDTO {
+
+    private Long id;
+
+    private MoveType type;
+
+    private String token;
+    private char[] userTiles;
+    private char[][] board;
+
+    public boolean isValid() {
+        if(this.id == null) throw new IllegalArgumentException("ID is missing");
+        if(this.type == null) throw new IllegalArgumentException("MoveType is missing");
+        if (this.token == null) throw new IllegalArgumentException("Token is missing");
+        if (this.userTiles == null) throw new IllegalArgumentException("UserTiles is missing");
+        if(this.board == null) throw new IllegalArgumentException("Board is missing");
+
+        return true;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public MoveType getType() {
+        return type;
+    }
+
+    public void setType(MoveType type) {
+        this.type = type;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public char[] getUserTiles() {
+        return userTiles;
+    }
+
+    public void setUserTiles(char[] userTiles) {
+        this.userTiles = userTiles;
+    }
+
+    public char[][] getBoard() {
+        return board;
+    }
+
+    public void setBoard(char[][] board) {
+        this.board = board;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/MessageGameStateMessageDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/MessageGameStateMessageDTO.java
@@ -1,0 +1,51 @@
+package ch.uzh.ifi.hase.soprafs24.rest.dto;
+
+import ch.uzh.ifi.hase.soprafs24.constant.MessageStatus;
+
+public class MessageGameStateMessageDTO {
+
+    private Long gameId;
+
+    private MessageStatus messageStatus;
+    private String message;
+    private GameStateDTO gameState;
+
+    public MessageGameStateMessageDTO(Long gameId, MessageStatus messageStatus, String message, GameStateDTO dto) {
+        this.gameId = gameId;
+        this.messageStatus = messageStatus;
+        this.message = message;
+        this.gameState = dto;
+    }
+
+    public Long getGameId() {
+        return gameId;
+    }
+
+    public void setGameId(Long gameId) {
+        this.gameId = gameId;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public GameStateDTO getGameState() {
+        return gameState;
+    }
+
+    public void setGameState(GameStateDTO gameState) {
+        this.gameState = gameState;
+    }
+
+    public MessageStatus getMessageStatus() {
+        return messageStatus;
+    }
+
+    public void setMessageStatus(MessageStatus messageStatus) {
+        this.messageStatus = messageStatus;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/GameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/GameService.java
@@ -1,0 +1,40 @@
+package ch.uzh.ifi.hase.soprafs24.service;
+
+import ch.uzh.ifi.hase.soprafs24.entity.Game;
+import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.repository.GameRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@Transactional
+public class GameService {
+    private final Logger log = LoggerFactory.getLogger(GameService.class);
+
+    private final GameRepository gameRepository;
+
+    @Autowired
+    public GameService(@Qualifier("gameRepository") GameRepository gameRepository) {
+    this.gameRepository = gameRepository;
+    }
+
+    public Game createGame(Game game, User host) {
+        game.addUser(host);
+        return gameRepository.save(game);
+    }
+
+    public Optional<Game> getGameById(Long id) {
+        return gameRepository.findById(id);
+    }
+
+    public Game joinGame(Game game, User user) {
+        game.addUser(user);
+        return gameRepository.save(game);
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketConfig.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketConfig.java
@@ -1,0 +1,25 @@
+package ch.uzh.ifi.hase.soprafs24.websocket;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/connections")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.setApplicationDestinationPrefixes("/ws");
+        registry.enableSimpleBroker("/topic","/queue");
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketController.java
@@ -1,0 +1,66 @@
+package ch.uzh.ifi.hase.soprafs24.websocket;
+
+import ch.uzh.ifi.hase.soprafs24.constant.MessageStatus;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.MessageGameStateMessageDTO;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.GameStateDTO;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+import org.slf4j.Logger;
+import org.springframework.web.server.ResponseStatusException;
+
+@Controller
+public class WebSocketController {
+
+    @Autowired
+    SimpMessagingTemplate simpleMessagingTemplate;
+
+    private static final Logger logger = LoggerFactory.getLogger(WebSocketController.class);
+
+
+    // ------------------ Game State ---------------------------------------
+    @MessageMapping("/game_states/{gameId}")
+    @SendTo("/topic/game_states/{gameId}")
+    public void handleGameStates(@DestinationVariable String gameId, GameStateDTO gameState) {
+        logger.debug("[LOG] Game endpoint reached with gameId: '{}' and gameState entity: '{}'",gameId, gameState.toString());
+        // Verify DTO
+        try {
+            gameState.isValid();
+        } catch (IllegalArgumentException exception) {
+            simpleMessagingTemplate.convertAndSend("/topic/game_states/"+gameId, new MessageGameStateMessageDTO(
+                    Long.valueOf(gameId),
+                    MessageStatus.ERROR,
+                    exception.getMessage(),
+                    null
+            ));
+        }
+        if(gameState.getId() != Long.valueOf(gameId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN,"The game id of the object and destination are not equal!");
+        }
+
+        // verify words of game
+
+        // Add new gameState no database (if submit)
+
+        // Send gameState back to users
+
+
+
+        simpleMessagingTemplate.convertAndSend("/topic/game_states/"+gameId, new MessageGameStateMessageDTO(
+                Long.valueOf(gameId),
+                MessageStatus.SUCCESS,
+                "GameState successfully received",
+                gameState
+        ));
+    }
+
+
+
+    // ------------------ Moves ---------------------------------------------
+
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketControllerTest.java
@@ -1,0 +1,183 @@
+package ch.uzh.ifi.hase.soprafs24.websocket;
+
+import ch.uzh.ifi.hase.soprafs24.constant.MessageStatus;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.GameStateDTO;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.MessageGameStateMessageDTO;
+import org.junit.jupiter.api.*;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSession.Subscription;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+import org.springframework.web.socket.sockjs.client.SockJsClient;
+import org.springframework.web.socket.sockjs.client.Transport;
+import org.springframework.web.socket.sockjs.client.WebSocketTransport;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class WebSocketControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    private String wsConnectionUrl;
+    private static WebSocketStompClient client;
+
+    private static final String SUBSCRIBE_GAME_STATE_DESTINATION = "/topic/game_states/";
+
+    private CompletableFuture<MessageGameStateMessageDTO> completableFuture;
+    private StompSession session;
+    private Subscription subscription;
+
+    @BeforeAll
+    public void setUpOnce() {
+        client = new WebSocketStompClient(new SockJsClient(createTransportClient()));
+        client.setMessageConverter(new MappingJackson2MessageConverter());
+    }
+
+    @BeforeEach
+    public void setUp() {
+        completableFuture = new CompletableFuture<>();
+        String webSocketBaseUrl = "ws://localhost:" + port;
+        wsConnectionUrl = webSocketBaseUrl + "/connections";
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if(client.isRunning() && subscription != null && session.isConnected()
+        ) subscription.unsubscribe();
+        if(client.isRunning() && session.isConnected()) session.disconnect();
+    }
+
+    @Test
+    public void testConnectToWebSocketSuccessful() throws ExecutionException, InterruptedException, TimeoutException {
+        this.session = client.connect(this.wsConnectionUrl, new StompSessionHandlerAdapter() {})
+                .get(10, TimeUnit.SECONDS);
+
+        assertNotNull(session);
+        assertTrue(session.isConnected(), "WebSocket session should be connected");
+    }
+
+    @Test
+    public void SubscribeToGameStates_SuccessfulSubscription_returnsGameStates()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        // Assign
+        completableFuture = new CompletableFuture<>();
+        StompFrameHandler stompFrameHandler = new MessageGameStateDTOHandler(completableFuture);
+        session = client.connect(this.wsConnectionUrl, new StompSessionHandlerAdapter() {})
+                .get(10, TimeUnit.SECONDS);
+
+        assertNotNull(session);
+        assertTrue(session.isConnected(), "WebSocket session should be connected");
+
+        Long gameId = 1L;
+
+        // Act 1: Subscribe
+        subscription = session.subscribe(SUBSCRIBE_GAME_STATE_DESTINATION + gameId, stompFrameHandler);
+
+        // Assert 1
+        assertNotNull(subscription);
+        assertNotNull(subscription.getSubscriptionId());
+
+        // Simulate message reception
+        MessageGameStateMessageDTO testMessage = new MessageGameStateMessageDTO(
+                gameId, MessageStatus.SUCCESS, "GameState successfully received", new GameStateDTO()
+        );
+
+        // Act 2: Manually trigger the handler
+        stompFrameHandler.handleFrame(new StompHeaders(), testMessage);
+
+        // Assert 2
+        MessageGameStateMessageDTO msg = completableFuture.get(2, TimeUnit.SECONDS);
+        assertTrue(completableFuture.isDone(), "CompletableFuture should be done");
+        assertNotNull(msg);
+        assertEquals(gameId, msg.getGameId());
+        assertEquals(MessageStatus.SUCCESS, msg.getMessageStatus());
+        assertEquals("GameState successfully received", msg.getMessage());
+        assertNotNull(msg.getGameState());
+    }
+
+    /**
+     * Test multiple subscriptions receive the same message
+     */
+    @Test
+    public void testMultipleSubscriptions_receiveSameMessage() throws Exception {
+        Long gameId = 1L;
+        session = client.connect(this.wsConnectionUrl, new StompSessionHandlerAdapter() {})
+                .get(10, TimeUnit.SECONDS);
+
+        CompletableFuture<MessageGameStateMessageDTO> completableFuture1 = new CompletableFuture<>();
+        CompletableFuture<MessageGameStateMessageDTO> completableFuture2 = new CompletableFuture<>();
+
+        // Subscribe twice
+        Subscription subscription1 = session.subscribe(SUBSCRIBE_GAME_STATE_DESTINATION + gameId, new MessageGameStateDTOHandler(completableFuture));
+        Subscription subscription2 = session.subscribe(SUBSCRIBE_GAME_STATE_DESTINATION + gameId, new MessageGameStateDTOHandler(completableFuture2));
+
+        assertNotNull(subscription1, "First subscription should be successful");
+        assertNotNull(subscription2, "Second subscription should be successful");
+
+        // Simulate receiving a message
+        MessageGameStateMessageDTO testMessage = new MessageGameStateMessageDTO(
+                gameId,
+                MessageStatus.SUCCESS,
+                "GameState successfully received",
+                new GameStateDTO()
+        );
+
+        // Manually trigger message handlers
+        new MessageGameStateDTOHandler(completableFuture1).handleFrame(new StompHeaders(), testMessage);
+        new MessageGameStateDTOHandler(completableFuture2).handleFrame(new StompHeaders(), testMessage);
+
+        // Verify both subscriptions received the same message
+        MessageGameStateMessageDTO msg1 = completableFuture1.get(2, TimeUnit.SECONDS);
+        MessageGameStateMessageDTO msg2 = completableFuture2.get(2, TimeUnit.SECONDS);
+
+        assertNotNull(msg1, "First subscriber should receive the message");
+        assertNotNull(msg2, "Second subscriber should receive the message");
+
+        assertEquals(msg1.getGameId(), gameId, "Game ID should match");
+        assertEquals(msg2.getGameId(), gameId, "Game ID should match");
+
+        assertEquals(msg1.getMessage(), "GameState successfully received", "Message content should match");
+        assertEquals(msg2.getMessage(), "GameState successfully received", "Message content should match");
+
+        assertEquals(msg1.getMessageStatus(), MessageStatus.SUCCESS, "Status should be SUCCESS");
+        assertEquals(msg2.getMessageStatus(), MessageStatus.SUCCESS, "Status should be SUCCESS");
+    }
+    private static List<Transport> createTransportClient() {
+        return List.of(new WebSocketTransport(new StandardWebSocketClient()));
+    }
+
+    private class MessageGameStateDTOHandler implements StompFrameHandler {
+        private final CompletableFuture<MessageGameStateMessageDTO> completableFuture;
+        public MessageGameStateDTOHandler(CompletableFuture<MessageGameStateMessageDTO> completableFuture) {
+            this.completableFuture = completableFuture;
+        }
+        @Override
+        public Type getPayloadType(StompHeaders stompHeaders) {
+            return MessageGameStateMessageDTO.class;
+        }
+
+        @Override
+        public void handleFrame(StompHeaders stompHeaders, Object o) {
+            completableFuture.complete((MessageGameStateMessageDTO) o);
+        }
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketControllerTest.java
@@ -127,7 +127,7 @@ public class WebSocketControllerTest {
         CompletableFuture<MessageGameStateMessageDTO> completableFuture2 = new CompletableFuture<>();
 
         // Subscribe twice
-        Subscription subscription1 = session.subscribe(SUBSCRIBE_GAME_STATE_DESTINATION + gameId, new MessageGameStateDTOHandler(completableFuture));
+        Subscription subscription1 = session.subscribe(SUBSCRIBE_GAME_STATE_DESTINATION + gameId, new MessageGameStateDTOHandler(completableFuture1));
         Subscription subscription2 = session.subscribe(SUBSCRIBE_GAME_STATE_DESTINATION + gameId, new MessageGameStateDTOHandler(completableFuture2));
 
         assertNotNull(subscription1, "First subscription should be successful");


### PR DESCRIPTION
Fixes #91 and  #116

- adds websocket handshake
- adds endpoint for subscribing and sending the game state
- adds entities used for websocket traffic (messages, gameStateDto, Status Enums)

Still TODO: implement validation of new words and case destinction based on move type 