### PR TITLE
184 fix bugs with invitations creating a lobby

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/GameInvitationService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/GameInvitationService.java
@@ -57,8 +57,12 @@ public class GameInvitationService {
         Game game = optionalGame.get();
         User sender = optionalSender.get();
         User target = optionalTarget.get();
-        if(gameInvitationRepository.findByGameAndTarget(game, target).isPresent()) throw new IllegalArgumentException("Game invitation already exists");
-
+        if(gameInvitationRepository.findByGameAndTarget(game, target).isPresent()) {
+            log.info("Game invitation already exists - overwriting existing invitation");
+            GameInvitation gameInvitation = gameInvitationRepository.findByGameAndTarget(game, target).get();
+            gameInvitation.setStatus(InvitationStatus.PENDING);
+            return gameInvitationRepository.saveAndFlush(gameInvitation);
+        }
 
         GameInvitation gameInvitation = new GameInvitation();
         gameInvitation.setGame(game);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/GameInvitationService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/GameInvitationService.java
@@ -72,6 +72,10 @@ public class GameInvitationService {
     public GameInvitation updateGameInvitationStatus(GameInvitation gameInvitation, InvitationStatus status) throws UserNotFoundException, GameNotFoundException {
         if(gameInvitation == null || gameInvitation.getId() == null) throw new IllegalArgumentException("Game invitation cannot be null");
         if(status == null) throw new IllegalArgumentException("Status cannot be null");
+        if(gameInvitation.getGame() == null || gameInvitation.getGame().getId() == null || gameService.getGameById(gameInvitation.getGame().getId()).isEmpty()) throw new GameNotFoundException("Game not found");
+        if(gameInvitation.getSender() == null || gameInvitation.getSender().getId() == null || userService.getUserById(gameInvitation.getSender().getId()).isEmpty()) throw new UserNotFoundException("Sender not found");
+        if(gameInvitation.getTarget() == null || gameInvitation.getTarget().getId() == null || userService.getUserById(gameInvitation.getTarget().getId()).isEmpty()) throw new UserNotFoundException("Target not found");
+        if(gameInvitation.getGame().getUsers().size() >= 2) throw new IllegalArgumentException("Game is already full");
         gameInvitation.setStatus(status);
         if(status==InvitationStatus.ACCEPTED) {
             userService.updateUserStatus(gameInvitation.getTarget(), UserStatus.IN_GAME);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/GameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/GameService.java
@@ -1,6 +1,7 @@
 package ch.uzh.ifi.hase.soprafs24.service;
 
 import ch.uzh.ifi.hase.soprafs24.constant.GameStatus;
+import ch.uzh.ifi.hase.soprafs24.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs24.constant.errors.GameNotFoundException;
 import ch.uzh.ifi.hase.soprafs24.constant.errors.InvalidGameStatusException;
 import ch.uzh.ifi.hase.soprafs24.constant.errors.UserNotFoundException;
@@ -39,6 +40,8 @@ public class GameService {
         game.setHost(host);
         game.getUsers().add(host);
         game.setGameStatus(GameStatus.CREATED);
+        game.getHost().setInGame(true);
+        game.getHost().setStatus(UserStatus.IN_GAME);
         return gameRepository.save(game);
     }
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/GameInvitationServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/GameInvitationServiceTest.java
@@ -5,6 +5,7 @@ import ch.uzh.ifi.hase.soprafs24.constant.errors.UserNotFoundException;
 import ch.uzh.ifi.hase.soprafs24.entity.Game;
 import ch.uzh.ifi.hase.soprafs24.entity.GameInvitation;
 import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.enums.InvitationStatus;
 import ch.uzh.ifi.hase.soprafs24.repository.GameInvitationRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -112,5 +114,34 @@ class GameInvitationServiceTest {
         // Act & Assert
         assertThrows(IllegalArgumentException.class, () ->
                 gameInvitationService.createGameInvitation(Optional.of(game), Optional.of(sender), Optional.of(target)));
+    }
+
+    @Test
+    void updateGameInvitation_gameAlreadyFull_throwsException() throws UserNotFoundException, GameNotFoundException {
+        // Assign
+        Game game = new Game(); game.setId(1L);
+        User sender = new User(); sender.setId(1L);
+        User target = new User(); target.setId(2L);
+        User userInGame = new User(); userInGame.setId(3L);
+        game.setUsers(List.of(sender, userInGame));
+
+        GameInvitation gameInvitation = new GameInvitation();
+        gameInvitation.setId(1L);
+        gameInvitation.setGame(game);
+        gameInvitation.setSender(sender);
+        gameInvitation.setTarget(target);
+
+        Mockito.when(gameInvitationRepository.findById(1L)).thenReturn(Optional.of(gameInvitation));
+        Mockito.when(gameService.getGameById(1L)).thenReturn(Optional.of(game));
+        Mockito.when(userService.getUserById(1L)).thenReturn(Optional.of(sender));
+        Mockito.when(userService.getUserById(2L)).thenReturn(Optional.of(target));
+
+        // Act & Assert
+         Exception exception = assertThrows(IllegalArgumentException.class, () ->
+                gameInvitationService.updateGameInvitationStatus(gameInvitation, InvitationStatus.ACCEPTED));
+         assertEquals("Game is already full", exception.getMessage());
+         Mockito.verify(gameInvitationRepository, Mockito.never()).saveAndFlush(any());
+         Mockito.verify(userService, Mockito.never()).updateUserStatus(any(), any());
+         Mockito.verify(gameService, Mockito.never()).joinGame(any(), any());
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/GameServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/GameServiceTest.java
@@ -66,7 +66,9 @@ public class GameServiceTest {
         // Assert
         assertNotNull(createdGame);
         assertEquals(testGame.getId(), createdGame.getId());
-        assertEquals(testHost, createdGame.getHost());
+        assertEquals(testHost.getId(), createdGame.getHost().getId());
+        assertEquals(UserStatus.IN_GAME, createdGame.getHost().getStatus());
+        assertEquals(true, createdGame.getHost().isInGame());
         verify(gameRepository, times(1)).save(any(Game.class));
     }
 


### PR DESCRIPTION
Fix the following bugs:

1. Do not allow users to accept invitations to games which are already full
2. If a user declined an invitation allow the sender to send another invitation -> reuse invitation from before
3. If a host creates a game, set the host's status to INGAME